### PR TITLE
CPC setting commands sent every hour

### DIFF
--- a/nano_config.yml
+++ b/nano_config.yml
@@ -23,7 +23,7 @@ data_config:
   "serial_bytesize": 7
   "serial_parity": "E"
   "serial_timeout": 0.05
-  "start_commands" : ['TS440','TO460']
+  "start_commands" : ['TS440','TO460',"TC100"]
   "fill_index": 10
 labjack : 470024288
 labjack_io :

--- a/smpscontrol/_cpcserial.py
+++ b/smpscontrol/_cpcserial.py
@@ -49,6 +49,13 @@ class CPCSerial:
 
         while not self.stop_threads.is_set():
             try:
+                # Send startup commands once an hour
+                if time.monotonic() % (60 * 60) < update_time:
+                    if data_config["start_commands"]:
+                        for start_command in data_config["start_commands"]:
+                            ser.write((start_command + "\r").encode())
+                            ser.readline().decode().rstrip()
+
                 # Store responses in a list
                 responses = []
 


### PR DESCRIPTION
Power surges wipe out custom CPC settings, this prevents the CPC from operating at the wrong settings for extended periods of time